### PR TITLE
Fix: Bundle requests and plyer into standalone binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Build with PyInstaller
         run: |
-          pyinstaller --onefile --windowed SimBriefPyDownloader.spec
+          pyinstaller --onefile --windowed SimBriefPyDownloader.py
 
       - name: Upload Binary
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build Linux Binary
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-tk
+          pip install -r requirements.txt
+
+      - name: Build with PyInstaller
+        run: |
+          pyinstaller --onefile --windowed SimBriefPyDownloader.spec
+
+      - name: Upload Binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: SimBriefPyDownloader-Linux
+          path: dist/SimBriefPyDownloader

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+plyer
+pyinstaller


### PR DESCRIPTION
Hey, I'd like to make this easier to run on Linux by adding a PyInstaller build script that automatically includes the python modules `requests` and `plyer` in the binary, making it a standalone binary. Some people (including me) do not like to install python packages to system python. Would you be open to a PR for that?